### PR TITLE
A Failure To DM Is Not A Total Failure

### DIFF
--- a/src/interactions/modals/handlers/submit-issue-modal.ts
+++ b/src/interactions/modals/handlers/submit-issue-modal.ts
@@ -96,10 +96,23 @@ export const submitIssueModalHandler: IModalHandler = {
             embeds: [issueEmbed],
         });
 
-        await interaction.user.send({
-            content: `Your ${issueConfig.longName} was successfully submitted! Here's a copy so you can easily find it later to track progress.`,
-            embeds: [issueEmbed],
-        });
+        try {
+            await interaction.user.send({
+                content: `Your ${issueConfig.longName} was successfully submitted! Here's a copy so you can easily find it later to track progress.`,
+                embeds: [issueEmbed],
+            });
+        } catch {
+            console.error(`Failed to DM ticket to user ${interaction.user.globalName}`);
+
+            try {
+                await interaction.followUp({
+                    content: `Your ${issueConfig.longName} was successfully submitted, but I failed to DM it to you. Use the ticket number link above to track progress.`,
+                    ephemeral: true
+                });
+            } catch (error) {
+                console.error(error);
+            }
+        }
     },
 };
 


### PR DESCRIPTION
- `/submitbug` and `/submitfeature` shouldn't send a failure message where unable to send a DM, especially if the user's DMs are closed:
![failed to DM](https://github.com/user-attachments/assets/f7c6d82b-3b7b-45f3-9322-983b11230522)
- So tack on an ephemeral followUp noting that the DM failed to be sent, and call out where to track the issue progress at.
- I do *not* like swallowing the error on the second followUp, but by then the first followUp with the ticket embed has already gone through, and the interaction has been resolved.
  - But it beats showing a failure message effectively stating "failed to notify you about failing to notify you".

### This is completely untested.